### PR TITLE
Add push event condition to build and deploy jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: test
+    if: github.event_name == 'push'  
     
     steps:
       - name: Checkout
@@ -74,6 +75,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name == 'push'  
     
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
Updated the GitHub Actions workflow to ensure the build and deploy jobs only run on push events by adding an 'if: github.event_name == 'push'' condition to both jobs.