### PR TITLE
Update deploy workflow permissions and trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  issues: write
 
 
 concurrency:
@@ -22,7 +23,7 @@ concurrency:
 jobs:
   nightly-tests:
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     
     steps:
       - name: Checkout


### PR DESCRIPTION
Grants write permission to issues and allows the nightly-tests job to run on both 'schedule' and 'workflow_dispatch' events. This enables manual triggering of nightly tests and issue management within the workflow.