### PR TITLE
Enable email notifications in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -358,8 +358,8 @@ jobs:
             echo "console_warnings=No test output to analyze" >> $GITHUB_OUTPUT
           fi
 
-      - name: Send email notification (optional)
-        if: false  # Disable email notifications until secrets are configured
+      - name: Send email notification 
+        if: always()    
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com


### PR DESCRIPTION
Changed the email notification step in the deploy workflow to always run instead of being disabled. This ensures notifications are sent regardless of previous job outcomes.