### PR TITLE
Increase style size limits in angular.json

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -44,8 +44,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "8kB",
+                  "maximumError": "12kB"
                 }              ],
               "outputHashing": "all",
               "baseHref": "/Ionut-gardu/"
@@ -65,8 +65,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "8kB",
+                  "maximumError": "12kB"
                 }
               ],
               "outputHashing": "all",


### PR DESCRIPTION
Raised 'anyComponentStyle' maximumWarning from 4kB to 8kB and maximumError from 8kB to 12kB to allow for larger component styles before warnings and errors are triggered.